### PR TITLE
Add login error feedback

### DIFF
--- a/shiny/server.R
+++ b/shiny/server.R
@@ -61,6 +61,7 @@ server <- function(input, output, session) {
 
     user_id <- input$user_id
     if (passwords[user_id] == submitted_password) {
+      shinyjs::html("login_error", "")
       output$page <- renderUI({
         render_voting_page()
       })
@@ -161,7 +162,9 @@ server <- function(input, output, session) {
         col.names = TRUE,
         quote = FALSE
       )
-      get_mutation_trigger_source("login")         
+      get_mutation_trigger_source("login")
+    } else {
+      shinyjs::html("login_error", "Wrong password. Please try again.")
     }
   })
 

--- a/shiny/ui.R
+++ b/shiny/ui.R
@@ -17,6 +17,10 @@ login_page <- function() {
           value = cfg_selected_user_id
         ),
         passwordInput("passwd", "Password", value = ""),
+        div(
+          id = "login_error",
+          style = "color:red;"
+        ),
         br(),
         actionButton("loginBtn", "Log in"),
         br(),


### PR DESCRIPTION
## Summary
- show placeholder to display login error messages
- reset login error message on successful login
- display error when wrong password is entered

## Testing
- `Rscript -e "print('test')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b7d1cc5e4832c8c4b8c8a8457f068