### PR TITLE
Switch to shinyauthr session IDs

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -125,6 +125,6 @@ cfg_user_annotations_colnames <- c(
    "alternative_vartype",
    "observation",
    "comment",
-   "shiny_session_id",
+   "shinyauthr_session_id",
    "time_till_vote_casted_in_seconds"
 )

--- a/R/modules/leaderboard_module.R
+++ b/R/modules/leaderboard_module.R
@@ -29,7 +29,7 @@ leaderboardServer <- function(id, login_trigger) {
             sep = "\t",
             stringsAsFactors = FALSE
           )
-          user_voted_images <- sum(!is.na(user_annotations_df$shiny_session_id))
+          user_voted_images <- sum(!is.na(user_annotations_df$shinyauthr_session_id))
           total_images <- total_images + user_voted_images
         }
         data.frame(institute = institute, users = total_users, total_images_voted = total_images)

--- a/R/modules/login_module.R
+++ b/R/modules/login_module.R
@@ -68,7 +68,8 @@ loginServer <- function(id, db_conn = NULL, log_out = reactive(NULL)) {
       req(credentials()$user_auth)
       list(
         user_id = credentials()$info$user,
-        voting_institute = input$institutes_id
+        voting_institute = input$institutes_id,
+        session_id = credentials()$info$sessionid
       )
     })
 

--- a/R/modules/user_stats_module.R
+++ b/R/modules/user_stats_module.R
@@ -23,10 +23,10 @@ userStatsServer <- function(id, login_trigger) {
         sep = "\t",
         stringsAsFactors = FALSE
       )
-      annotations_df <- annotations_df[!is.na(annotations_df$shiny_session_id), ]
+      annotations_df <- annotations_df[!is.na(annotations_df$shinyauthr_session_id), ]
 
       session_counts_df <- annotations_df %>%
-        group_by(shiny_session_id) %>%
+        group_by(shinyauthr_session_id) %>%
         summarise(images_voted = n(), .groups = 'drop')
 
       user_info <- read_json(user_info_file)

--- a/R/modules/voting_module.R
+++ b/R/modules/voting_module.R
@@ -107,9 +107,9 @@ votingServer <- function(id, login_trigger) {
       already_voted <- !is.na(previous_agreement) && previous_agreement != ""
       new_agreement <- input$agreement
 
-      # always update the agreement and the shiny_session_id
-      annotations_df[rowIdx, "agreement"] <- input$agreement 
-      annotations_df[rowIdx, "shinyauthr_session_id"] <- session$token
+      # always update the agreement and the shinyauthr_session_id
+      annotations_df[rowIdx, "agreement"] <- input$agreement
+      annotations_df[rowIdx, "shinyauthr_session_id"] <- session$userData$shinyauthr_session_id
 
       # only update if provided
       if (!is.null(input$alternative_vartype)) {
@@ -303,7 +303,7 @@ votingServer <- function(id, login_trigger) {
 
           # filter the annotations_df to only show the rows with the same session ID
           session_annotations_df <- annotations_df %>%
-            filter(shinyauthr_session_id == session$token)
+            filter(shinyauthr_session_id == session$userData$shinyauthr_session_id)
 
           print("Filtered Annotations DataFrame for the current session:")
           print(session_annotations_df)

--- a/R/server.R
+++ b/R/server.R
@@ -84,6 +84,7 @@ server <- function(input, output, session) {
     req(login_data())
     user_id <- login_data()$user_id
     voting_institute <- login_data()$voting_institute
+    session$userData$shinyauthr_session_id <- login_data()$session_id
 
     session$userData$userId <- user_id
     session$userData$votingInstitute <- voting_institute


### PR DESCRIPTION
## Summary
- expose shinyauthr session id in the login module
- store the session id for each Shiny session
- track votes by shinyauthr session id in voting, leaderboard and stats modules
- update user annotations column configuration

## Testing
- `bash codex_setup.sh` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6862b9fb1618832c8fa9db04ba36e2e9