### PR TITLE
Store credentials in sqlite

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -52,11 +52,20 @@ load_config <- function() {
   cfg$vote_counts_cols <- c(unlist(cfg$vote2dbcolumn_map, use.names = FALSE), "vote_count_total")
   cfg$db_cols <- c(cfg$db_general_cols, cfg$vote_counts_cols)
 
-  cfg$credentials_df <- data.frame(
-    user = names(cfg$user2passwords_map),
-    password = vapply(cfg$user2passwords_map, identity, character(1)),
-    stringsAsFactors = FALSE
-  )
+  con <- DBI::dbConnect(RSQLite::SQLite(), cfg$sqlite_file)
+  if ("credentials" %in% DBI::dbListTables(con)) {
+    cfg$credentials_df <- DBI::dbReadTable(con, "credentials")
+    names(cfg$credentials_df)[names(cfg$credentials_df) == "userid"] <- "user"
+  } else {
+    cfg$credentials_df <- data.frame(
+      user = character(),
+      password = character(),
+      password_retrieval_link = character(),
+      link_clicked_timestamp = character(),
+      stringsAsFactors = FALSE
+    )
+  }
+  DBI::dbDisconnect(con)
 
   return(cfg)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -96,6 +96,17 @@ init_external_database <- function(base_dir = getwd(), db_name = "db.sqlite") {
         vote_count_total INTEGER DEFAULT 0
       )
     ")
+
+    DBI::dbExecute(con, "
+      CREATE TABLE credentials (
+        userid TEXT,
+        password TEXT,
+        password_retrieval_link TEXT,
+        link_clicked_timestamp TEXT
+      )
+    ")
+
+    DBI::dbExecute(con, "INSERT INTO credentials(userid, password) VALUES('test','1234'),('test2','1234')")
     
     DBI::dbExecute(con, "
       CREATE TABLE sessionids (
@@ -165,6 +176,19 @@ init_external_database <- function(base_dir = getwd(), db_name = "db.sqlite") {
         sessionid TEXT,
         login_time TEXT,
         logout_time TEXT
+      )
+    ")
+  }
+
+  # Create credentials table if missing
+  if (!"credentials" %in% DBI::dbListTables(con)) {
+    cat("Creating credentials table\n")
+    DBI::dbExecute(con, "
+      CREATE TABLE credentials (
+        userid TEXT,
+        password TEXT,
+        password_retrieval_link TEXT,
+        link_clicked_timestamp TEXT
       )
     ")
   }

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -67,8 +67,5 @@ institute_ids:
 - University of Verona
 test_institute: Training_answers_not_saved
 selected_institute_id: CNAG
-user2passwords_map:
-  test: '1234'
-  test2: '1234'
 selected_user_id: Test
 cookie_expiry: 1

--- a/inst/shiny-app/default_config.yaml
+++ b/inst/shiny-app/default_config.yaml
@@ -67,8 +67,5 @@ institute_ids:
 - University of Verona
 test_institute: Training_answers_not_saved
 selected_institute_id: CNAG
-user2passwords_map:
-  test: '1234'
-  test2: '1234'
 selected_user_id: Test
 cookie_expiry: 1

--- a/tests/testthat/test-utils-functions.R
+++ b/tests/testthat/test-utils-functions.R
@@ -68,6 +68,7 @@ test_that("init_external_database creates database correctly", {
   tables <- dbListTables(con)
   expect_true("annotations" %in% tables)
   expect_true("sessionids" %in% tables)
+  expect_true("credentials" %in% tables)
   
   # Check annotations table structure
   annotations_info <- dbGetQuery(con, "PRAGMA table_info(annotations)")
@@ -81,6 +82,11 @@ test_that("init_external_database creates database correctly", {
   sessionids_info <- dbGetQuery(con, "PRAGMA table_info(sessionids)")
   expected_sessionids_columns <- c("user", "sessionid", "login_time", "logout_time")
   expect_true(all(expected_sessionids_columns %in% sessionids_info$name))
+
+  # Check credentials table structure
+  cred_info <- dbGetQuery(con, "PRAGMA table_info(credentials)")
+  expected_cred_cols <- c("userid", "password", "password_retrieval_link", "link_clicked_timestamp")
+  expect_true(all(expected_cred_cols %in% cred_info$name))
   
   dbDisconnect(con)
   
@@ -122,6 +128,9 @@ test_that("init_external_database works with data file", {
   
   # Check that data was loaded
   con <- dbConnect(RSQLite::SQLite(), db_path)
+
+  tables <- dbListTables(con)
+  expect_true("credentials" %in% tables)
   
   # Check that annotations were loaded
   row_count <- dbGetQuery(con, "SELECT COUNT(*) as count FROM annotations")


### PR DESCRIPTION
## Summary
- remove hardcoded credentials from configuration
- create `credentials` table when database is initialised
- read credentials from database in `load_config`
- update tests for the new table

## Testing
- `make test` *(fails: `/usr/bin/R` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874cfaf163c832cb7194d47cbb3ed63