### PR TITLE
Reuse voting leaflet map between images

### DIFF
--- a/inst/shiny-app/www/leaflet.js
+++ b/inst/shiny-app/www/leaflet.js
@@ -8,93 +8,120 @@
 // We set the image bounds to [[0,0], [height,width]] so that the top-left
 // corner is (0,0) and the bottom-right corner is (width,height).
 
-window.renderLeafletImageOverlay = function (el, x, data) {
-  console.log("renderLeafletImageOverlay called with data:", data);
-  if (!data || !data.imageUrl) {
-    console.error("No imageUrl provided in data");
-    return;
-  }
-
-  console.log("Leaflet map object:", this);
-  console.log("Container element:", el);
-  console.log("x:", x);
-
-  const map = this;
-  const imageUrl = data.imageUrl;
-
-  if (map.imageOverlayLayer) {
-    map.removeLayer(map.imageOverlayLayer);
-    map.imageOverlayLayer = null;
-  }
-
-  const img = new Image();
-  img.onload = function () {
-    const width = this.naturalWidth;
-    const height = this.naturalHeight;
-
-    console.log("Image loaded:", imageUrl, width, "x", height);
-
-    const bounds = L.latLngBounds([
-      [0, 0],
-      [height, width],
-    ]);
-
-    console.log("Image bounds:", bounds);
-
-    map.imageOverlayLayer = L.imageOverlay(imageUrl, bounds, {
-      interactive: true,
-    }).addTo(map);
-
-    // Fit and set padded max bounds
-    map.fitBounds(bounds, { animate: false });
-    const padX = width * 0.1;
-    const padY = height * 0.1;
-    map.setMaxBounds(
-      L.latLngBounds([
-        [-padY, -padX],
-        [height + padY, width + padX],
-      ])
-    );
-
-    // --- Zoom helpers ---
-    function fitView() {
-      map.fitBounds(bounds);
-    }
-
-    // Wire buttons once (idempotent)
-    function once(id, handler) {
-      const btn = el.querySelector(`#${id}`);
-      if (!btn) return;
-      if (!btn._bound) {
-        btn.addEventListener("click", handler);
-        btn._bound = true;
-      }
-    }
-
-    once("zoomIn", () => {
-      map.zoomIn(map.options.zoomDelta || 0.25);
-    });
-    once("zoomOut", () => {
-      const next = map.getZoom() - (map.options.zoomDelta || 0.25);
-      if (next >= map.options.minZoom) map.setZoom(next);
-      else map.setZoom(map.options.minZoom);
-    });
-    once("fitBtn", () => {
-      fitView();
-    });
-
-    // When the container is resized (e.g., input$image_width changes),
-    // recompute 'fit' and keep center stable
-    const resizeObserver = new ResizeObserver(() => {
-      // maintain center; re-fit bounds to container size
-      const center = map.getCenter();
-      const zoom = map.getZoom();
-      map.invalidateSize();
-      // Option: keep current zoom; or re-fit. Here we keep zoom & center.
-      map.setView(center, zoom, { animate: false });
-    });
-    // observe the widget container
-    resizeObserver.observe(el);
+window.renderLeafletImageOverlay = (function () {
+  const voteImageState = {
+    maps: {},
+    pending: {},
   };
-  img.src = imageUrl;
-};
+
+  function ensureStateEntry(id) {
+    if (!voteImageState.maps[id]) {
+      voteImageState.maps[id] = null;
+    }
+  }
+
+  function applyOverlay(map, el, imageUrl) {
+    if (!map || !el || !imageUrl) {
+      return;
+    }
+
+    if (map.imageOverlayLayer) {
+      map.removeLayer(map.imageOverlayLayer);
+      map.imageOverlayLayer = null;
+    }
+
+    const img = new Image();
+    img.onload = function () {
+      const width = this.naturalWidth;
+      const height = this.naturalHeight;
+
+      const bounds = L.latLngBounds([
+        [0, 0],
+        [height, width],
+      ]);
+
+      map.imageOverlayLayer = L.imageOverlay(imageUrl, bounds, {
+        interactive: true,
+      }).addTo(map);
+
+      map.fitBounds(bounds, { animate: false });
+      const padX = width * 0.1;
+      const padY = height * 0.1;
+      map.setMaxBounds(
+        L.latLngBounds([
+          [-padY, -padX],
+          [height + padY, width + padX],
+        ])
+      );
+
+      function once(id, handler) {
+        const btn = el.querySelector(`#${id}`);
+        if (!btn) return;
+        if (!btn._bound) {
+          btn.addEventListener("click", handler);
+          btn._bound = true;
+        }
+      }
+
+      once("zoomIn", () => {
+        map.zoomIn(map.options.zoomDelta || 0.25);
+      });
+      once("zoomOut", () => {
+        const next = map.getZoom() - (map.options.zoomDelta || 0.25);
+        if (next >= map.options.minZoom) map.setZoom(next);
+        else map.setZoom(map.options.minZoom);
+      });
+      once("fitBtn", () => {
+        map.fitBounds(bounds);
+      });
+
+      if (!map._voteImageResizeObserver) {
+        map._voteImageResizeObserver = new ResizeObserver(() => {
+          const center = map.getCenter();
+          const zoom = map.getZoom();
+          map.invalidateSize();
+          map.setView(center, zoom, { animate: false });
+        });
+        map._voteImageResizeObserver.observe(el);
+      }
+    };
+    img.src = imageUrl;
+  }
+
+  function registerMap(id, map, el) {
+    voteImageState.maps[id] = { map, el };
+    if (voteImageState.pending[id]) {
+      const imageUrl = voteImageState.pending[id];
+      delete voteImageState.pending[id];
+      applyOverlay(map, el, imageUrl);
+    }
+  }
+
+  function setOverlay(id, imageUrl) {
+    ensureStateEntry(id);
+    const entry = voteImageState.maps[id];
+    if (entry) {
+      applyOverlay(entry.map, entry.el, imageUrl);
+    } else {
+      voteImageState.pending[id] = imageUrl;
+    }
+  }
+
+  if (typeof Shiny !== "undefined" && Shiny.addCustomMessageHandler) {
+    Shiny.addCustomMessageHandler("voteImage:setOverlay", (message) => {
+      if (!message || !message.outputId) {
+        return;
+      }
+      setOverlay(message.outputId, message.imageUrl);
+    });
+  }
+
+  return function (el, x, data) {
+    const map = this;
+    const id = el.id;
+    registerMap(id, map, el);
+    if (data && data.imageUrl) {
+      setOverlay(id, data.imageUrl);
+    }
+  };
+})();


### PR DESCRIPTION
## Summary
- register each voting leaflet widget on the client and listen for `voteImage:setOverlay` messages to swap the displayed overlay without rebuilding the widget
- send the new overlay URL from the server whenever the active mutation changes so the existing map is reused across images

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ebeea6b640832cbd4ebf2220ac74d3