### PR TITLE
Reset leaflet voting image when advancing to next mutation

### DIFF
--- a/R/mod_voting.R
+++ b/R/mod_voting.R
@@ -614,17 +614,44 @@ votingServer <- function(
         }
       }
     )
+    create_voting_image_output <- function() {
+      leaflet::leafletOutput(
+        session$ns("voting_image"),
+        width = "100%",
+        height = "840px"
+      )
+    }
+
     output$voting_image_div <- shiny::renderUI({
       mut_df <- get_mutation()
       if (is.null(mut_df)) {
         return(NULL)
       }
       shiny::div(
-        leaflet::leafletOutput(
-          session$ns("voting_image"),
-          width = "100%",
-          height = "840px"
-        )
+        id = session$ns("voting_image_container"),
+        create_voting_image_output()
+      )
+    })
+
+    shiny::observeEvent(next_trigger(), {
+      if (!identical(get_mutation_trigger_source(), "next")) {
+        return()
+      }
+
+      session$onFlushed(
+        function() {
+          shiny::removeUI(
+            selector = paste0("#", session$ns("voting_image")),
+            immediate = TRUE
+          )
+          shiny::insertUI(
+            selector = paste0("#", session$ns("voting_image_container")),
+            where = "beforeEnd",
+            ui = create_voting_image_output(),
+            immediate = TRUE
+          )
+        },
+        once = TRUE
       )
     })
 


### PR DESCRIPTION
## Summary
- add a helper to consistently generate the voting leaflet output container
- remove and immediately reinsert the leaflet widget after each Next press so a fresh image is rendered

## Testing
- ⚠️ `Rscript -e 'testthat::test_file("tests/testthat/test-voting-module.R")'` *(fails: command not found: Rscript)*

------
https://chatgpt.com/codex/tasks/task_e_68ebf8e8ec14832cbc6f4d8383f284c7